### PR TITLE
Bug fix: Update redirection after successful registration

### DIFF
--- a/src/routes/auth/register-cloud/+page.svelte
+++ b/src/routes/auth/register-cloud/+page.svelte
@@ -35,7 +35,7 @@
       toast.info('Registered Successfully', {
         description: 'Please Login Now'
       });
-      goto('/login');
+      goto('/auth/login');
     } else {
       toast.error('Failed to register', {
         description: 'Please try again'


### PR DESCRIPTION
Changed the redirection route from '/login' to '/auth/login' after a successful registration to improve user experience.